### PR TITLE
Ensure MOF family list initializes dictionary

### DIFF
--- a/src/mofbuilder/core/moftoplibrary.py
+++ b/src/mofbuilder/core/moftoplibrary.py
@@ -78,6 +78,8 @@ class MofTopLibrary:
 
     def list_mof_family(self):
         # print mof_top_dict keys fit to screen
+        if self.mof_top_dict is None:
+            self._read_mof_top_dict(self.data_path)
         self.ostream.print_info("Available MOF Family:")
         self.ostream.print_info(" ".join(self.mof_top_dict.keys()))
         self.ostream.flush()


### PR DESCRIPTION
Added a check in list_mof_family to initialize mof_top_dict if it is None before printing available MOF families. This prevents potential errors when the dictionary is not yet loaded.